### PR TITLE
Fix/working example with env vars

### DIFF
--- a/examples/fly-go/main.go
+++ b/examples/fly-go/main.go
@@ -2,32 +2,50 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/dirien/pulumi-fly/sdk/go/fly"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
+
 	pulumi.Run(func(ctx *pulumi.Context) error {
+
+		cfg := config.New(ctx, "fly")
+		flyToken := cfg.RequireSecret("fly_api_token")
+
+		// Create explicit provider
+		flyProvider, err := fly.NewProvider(ctx, "fly-provider", &fly.ProviderArgs{
+			FlyApiToken: flyToken,
+		})
+		if err != nil {
+			return err
+		}
 
 		exampleApp, err := fly.NewApp(ctx, "example-app", &fly.AppArgs{
 			Name: pulumi.String("my-dirien-app"),
 			Org:  pulumi.String("personal"),
-		})
+		}, pulumi.Provider(flyProvider))
 		if err != nil {
 			return err
 		}
 
-		_, err = fly.NewIp(ctx, "example-ip", &fly.IpArgs{
+		exampleIpV4, err := fly.NewIp(ctx, "example-ip", &fly.IpArgs{
 			App:  exampleApp.Name,
 			Type: pulumi.String("v4"),
-		})
+		}, pulumi.Provider(flyProvider))
 		if err != nil {
 			return err
 		}
-		_, err = fly.NewIp(ctx, "example-ip-v6", &fly.IpArgs{
+
+		exampleIpV6, err := fly.NewIp(ctx, "example-ip-v6", &fly.IpArgs{
 			App:  exampleApp.Name,
 			Type: pulumi.String("v6"),
-		})
+		}, pulumi.Provider(flyProvider))
+		if err != nil {
+			return err
+		}
 
 		for _, region := range []string{"ams", "cdg", "fra"} {
 
@@ -36,16 +54,20 @@ func main() {
 				Region: pulumi.String(region),
 				Name:   pulumi.Sprintf("my-dirien-app-%s", region),
 				Image:  pulumi.String("dirien/hello-server:latest"),
+				Env: pulumi.StringMap{
+					"FLY_PROCESS_GROUP": pulumi.String("app"),
+					"PRIMARY_REGION":    pulumi.String(region),
+				},
 				Services: fly.MachineServiceArray{
-					fly.MachineServiceArgs{
+					&fly.MachineServiceArgs{
 						Ports: fly.MachineServicePortArray{
-							fly.MachineServicePortArgs{
+							&fly.MachineServicePortArgs{
 								Port: pulumi.Int(80),
 								Handlers: pulumi.StringArray{
 									pulumi.String("http"),
 								},
 							},
-							fly.MachineServicePortArgs{
+							&fly.MachineServicePortArgs{
 								Port: pulumi.Int(443),
 								Handlers: pulumi.StringArray{
 									pulumi.String("tls"),
@@ -59,7 +81,8 @@ func main() {
 				},
 				Cpus:   pulumi.Int(1),
 				Memory: pulumi.Int(256),
-			}, pulumi.DependsOn([]pulumi.Resource{exampleApp}))
+			}, pulumi.DependsOn([]pulumi.Resource{exampleApp, exampleIpV4, exampleIpV6}),
+				pulumi.Provider(flyProvider))
 			if err != nil {
 				return err
 			}

--- a/examples/fly-go/main.go
+++ b/examples/fly-go/main.go
@@ -57,8 +57,8 @@ func main() {
 						InternalPort: pulumi.Int(8080),
 					},
 				},
-				Cpus:     pulumi.Int(1),
-				Memorymb: pulumi.Int(256),
+				Cpus:   pulumi.Int(1),
+				Memory: pulumi.Int(256),
 			}, pulumi.DependsOn([]pulumi.Resource{exampleApp}))
 			if err != nil {
 				return err


### PR DESCRIPTION
This change does a few things.

1. to make it so that env vars do not have to be and can take full advantage of the pulumi.yaml file, a config block was added

```go
cfg := config.New(ctx, "fly")
flyToken := cfg.RequireSecret("fly_api_token")
```

then, we create the provider explicitly and pass in the fly token from the config

```go
flyProvider, err := fly.NewProvider(ctx, "fly-provider", &fly.ProviderArgs{
	FlyApiToken: flyToken,
})
if err != nil {
	return err
}
```

2. Best that I could find, this pulumi provider is using v1 of the machines API. This mean that dns records are not automatically setup for the fly and and while it deploys fine, it is essentially "orphaned". To fix this, we can inject the following vars into the machine

```go
Env: pulumi.StringMap{
    "FLY_PROCESS_GROUP": pulumi.String("app"),
    "PRIMARY_REGION":    pulumi.String(region),
},
```

This will ensure that once the app is deploy it will automatically get a *.fly.dev domain issued to it.

A note on this. I believe all of this would be handled automatically in v2 of the fly api. However, it also appears that this repo is bridging from a TF provider that is no longer maintained. There are some forks of the OG fly tf provider but all of them are largely not being updated much either. As such, a little bit of extra config is required.